### PR TITLE
Feature/405332 http headers middleware

### DIFF
--- a/src/EPR.Producer.PRN.Frontend.UI.UnitTests/EPR.Producer.PRN.Frontend.UI.UnitTests.csproj
+++ b/src/EPR.Producer.PRN.Frontend.UI.UnitTests/EPR.Producer.PRN.Frontend.UI.UnitTests.csproj
@@ -12,8 +12,14 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+	<!-- Test Coverage to be included in Sonarqube reports -->
+	<PackageReference Include="coverlet.msbuild" Version="3.2.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EPR.Producer.PRN.Frontend.UI.UnitTests/Middleware/SecurityHeaderMiddlewareTests.cs
+++ b/src/EPR.Producer.PRN.Frontend.UI.UnitTests/Middleware/SecurityHeaderMiddlewareTests.cs
@@ -1,34 +1,95 @@
 ﻿using EPR.Producer.PRN.Frontend.UI.Middleware.Auth;
 using Microsoft.AspNetCore.Http;
 using Moq;
+using System.Text;
 
 namespace EPR.Producer.PRN.Frontend.UI.UnitTests.Middleware
 {
     [TestClass]
     public class SecurityHeaderMiddlewareTests
     {
-        [TestMethod]
-        public async Task InvokeAsync_Returns_Expected_X_Content_Type_Options_Header()
+        private readonly DefaultHttpContext _context = new DefaultHttpContext();
+        private readonly Mock<Microsoft.Extensions.Configuration.IConfiguration> _mockConfiguration = new();
+        private SecurityHeaderMiddleware _middleware = default!;
+
+        [TestInitialize]
+        public void Setup()
         {
-            // Arrange
-            var middleware = new SecurityHeaderMiddleware(next: (_) =>
+            _middleware = new SecurityHeaderMiddleware(next: (_) =>
             {
                 return Task.CompletedTask;
             });
+        }
 
-            // Create the DefaultHttpContext
-            var context = new DefaultHttpContext();
-            var mockConfiguration = new Mock<Microsoft.Extensions.Configuration.IConfiguration>();
-
-            // Act
-            await middleware.InvokeAsync(context, mockConfiguration.Object);
+        [DataRow("Content-Security-Policy")]
+        [DataRow("Permissions-Policy")]
+        [TestMethod]
+        public async Task InvokeAsync_Returns_Expected_Header(string header)
+        {
+            // Arrange + Act
+            await _middleware.InvokeAsync(_context, _mockConfiguration.Object);
 
             // Assert
-            Assert.IsTrue(context.Response.Headers.ContainsKey("X-Content-Type-Options"));
+            Assert.IsTrue(_context.Response.Headers.ContainsKey(header));
+        }
 
-            Microsoft.Extensions.Primitives.StringValues expectedValue;
-            context.Response.Headers.TryGetValue("X-Content-Type-Options", out expectedValue);
-            Assert.AreEqual(expectedValue.ToString(), "nosniff");
+        [DataRow("Cross-Origin-Embedder-Policy", "require-corp")]
+        [DataRow("Cross-Origin-Opener-Policy", "same-origin")]
+        [DataRow("Cross-Origin-Resource-Policy", "same-origin")]
+        [DataRow("Referrer-Policy", "strict-origin-when-cross-origin")]
+        [DataRow("X-Content-Type-Options", "nosniff")]
+        [DataRow("X-Frame-Options", "deny")]
+        [DataRow("X-Permitted-Cross-Domain-Policies", "none")]
+        [DataRow("X-Robots-Tag", "noindex, nofollow")]
+        [DataTestMethod]
+        public async Task InvokeAsync_Returns_Expected_Header_And_Value(string header, string headerValue)
+        {
+            // Arrange + Act
+            await _middleware.InvokeAsync(_context, _mockConfiguration.Object);
+
+            // Assert
+            Assert.IsTrue(_context.Response.Headers.ContainsKey(header));
+            _context.Response.Headers.TryGetValue(header, out var actualHeaderValue);
+            Assert.AreEqual(actualHeaderValue.ToString(), headerValue);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Returns_Expected_Nonce_Item()
+        {
+            // Arrange + Act
+            await _middleware.InvokeAsync(_context, _mockConfiguration.Object);
+
+            // Assert
+            Assert.IsTrue(_context.Items.ContainsKey("ScriptNonce"));
+        }
+
+        [TestMethod]
+        public void GetContentSecurityPolicyHeader_Returns_Expected_Header_String()
+        {
+            // Arranage
+            var nonce = "nonce";
+            var whitelistedFormActionAddresses = "whitelistedFormActionAddresses";
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("default-src 'self'").Append(';');
+            sb.Append("object-src 'none'").Append(';');
+            sb.Append("frame-ancestors 'none'").Append(';');
+            sb.Append("upgrade-insecure-requests").Append(';');
+            sb.Append("block-all-mixed-content").Append(';');
+            sb.Append($"script-src 'self' 'nonce-{nonce}' https://tagmanager.google.com https://*.googletagmanager.com").Append(';');
+            sb.Append("img-src 'self' www.googletagmanager.com https://ssl.gstatic.com https://www.gstatic.com ");
+            sb.Append("https://*.google-analytics.com https://*.googletagmanager.com").Append(';');
+            sb.Append($"form-action 'self' {whitelistedFormActionAddresses}").Append(';');
+            sb.Append("style-src 'self' https://tagmanager.google.com https://fonts.googleapis.com").Append(';');
+            sb.Append("font-src 'self' https://fonts.gstatic.com data:").Append(';');
+            sb.Append("connect-src 'self' https://*.google-analytics.com ");
+            sb.Append("https://*.analytics.google.com https://*.googletagmanager.com");
+
+            // Act
+            string actual = SecurityHeaderMiddleware.GetContentSecurityPolicyHeader(nonce, whitelistedFormActionAddresses);
+
+            // Assert
+            Assert.AreEqual(actual, sb.ToString());
         }
     }
 }

--- a/src/EPR.Producer.PRN.Frontend.UI.UnitTests/Middleware/SecurityHeaderMiddlewareTests.cs
+++ b/src/EPR.Producer.PRN.Frontend.UI.UnitTests/Middleware/SecurityHeaderMiddlewareTests.cs
@@ -1,0 +1,34 @@
+﻿using EPR.Producer.PRN.Frontend.UI.Middleware.Auth;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace EPR.Producer.PRN.Frontend.UI.UnitTests.Middleware
+{
+    [TestClass]
+    public class SecurityHeaderMiddlewareTests
+    {
+        [TestMethod]
+        public async Task InvokeAsync_Returns_Expected_X_Content_Type_Options_Header()
+        {
+            // Arrange
+            var middleware = new SecurityHeaderMiddleware(next: (_) =>
+            {
+                return Task.CompletedTask;
+            });
+
+            // Create the DefaultHttpContext
+            var context = new DefaultHttpContext();
+            var mockConfiguration = new Mock<Microsoft.Extensions.Configuration.IConfiguration>();
+
+            // Act
+            await middleware.InvokeAsync(context, mockConfiguration.Object);
+
+            // Assert
+            Assert.IsTrue(context.Response.Headers.ContainsKey("X-Content-Type-Options"));
+
+            Microsoft.Extensions.Primitives.StringValues expectedValue;
+            context.Response.Headers.TryGetValue("X-Content-Type-Options", out expectedValue);
+            Assert.AreEqual(expectedValue.ToString(), "nosniff");
+        }
+    }
+}

--- a/src/EPR.Producer.PRN.Frontend.UI/Constants/ContextKeys.cs
+++ b/src/EPR.Producer.PRN.Frontend.UI/Constants/ContextKeys.cs
@@ -1,0 +1,7 @@
+﻿namespace EPR.Producer.PRN.Frontend.UI.Constants
+{
+    public static class ContextKeys
+    {
+        public const string ScriptNonceKey = "ScriptNonce";
+    }
+}

--- a/src/EPR.Producer.PRN.Frontend.UI/Middleware/Auth/SecurityHeaderMiddleware.cs
+++ b/src/EPR.Producer.PRN.Frontend.UI/Middleware/Auth/SecurityHeaderMiddleware.cs
@@ -1,0 +1,79 @@
+﻿using System.Security.Cryptography;
+using EPR.Producer.PRN.Frontend.UI.Constants;
+
+namespace EPR.Producer.PRN.Frontend.UI.Middleware.Auth;
+
+public class SecurityHeaderMiddleware
+{
+    private const int DefaultBytesInNonce = 32;
+
+    private readonly RequestDelegate _next;
+    private readonly RandomNumberGenerator _random = RandomNumberGenerator.Create();
+
+    public SecurityHeaderMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+    public async Task SnibboAsync(HttpContext httpContext)
+    {
+        httpContext.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+        await _next(httpContext);
+    }
+
+    public async Task InvokeAsync(HttpContext httpContext, IConfiguration configuration)
+    {
+        var scriptNonce = GenerateNonce();
+        var whitelistedFormActionAddresses = configuration["AzureAdB2C:Instance"] ?? default!;
+
+        const string permissionsPolicy =
+            "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=()," +
+            "document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=()," +
+            "layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=()," +
+            "oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=()," +
+            "sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()";
+
+        httpContext.Response.Headers.Append("Content-Security-Policy", GetContentSecurityPolicyHeader(scriptNonce, whitelistedFormActionAddresses));
+        httpContext.Response.Headers.Append("Cross-Origin-Embedder-Policy", "require-corp");
+        httpContext.Response.Headers.Append("Cross-Origin-Opener-Policy", "same-origin");
+        httpContext.Response.Headers.Append("Cross-Origin-Resource-Policy", "same-origin");
+        httpContext.Response.Headers.Append("Permissions-Policy", permissionsPolicy);
+        httpContext.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
+        httpContext.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+        httpContext.Response.Headers.Append("X-Frame-Options", "deny");
+        httpContext.Response.Headers.Append("X-Permitted-Cross-Domain-Policies", "none");
+        httpContext.Response.Headers.Append("X-Robots-Tag", "noindex, nofollow");
+
+        httpContext.Items[ContextKeys.ScriptNonceKey] = scriptNonce;
+
+        await _next(httpContext);
+    }
+
+    private static string GetContentSecurityPolicyHeader(string scriptNonce, string whitelistedFormActionAddresses)
+    {
+        const string defaultSrc = "default-src 'self'";
+        const string objectSrc = "object-src 'none'";
+        const string frameAncestors = "frame-ancestors 'none'";
+        const string upgradeInsecureRequests = "upgrade-insecure-requests";
+        const string blockAllMixedContent = "block-all-mixed-content";
+        const string imgSrc =
+            "img-src 'self' www.googletagmanager.com https://ssl.gstatic.com https://www.gstatic.com " +
+            "https://*.google-analytics.com https://*.googletagmanager.com";
+        string scriptSrc =
+            $"script-src 'self' 'nonce-{scriptNonce}' https://tagmanager.google.com https://*.googletagmanager.com";
+        string formAction = $"form-action 'self' {whitelistedFormActionAddresses}";
+        const string styleSrc = "style-src 'self' https://tagmanager.google.com https://fonts.googleapis.com";
+        const string fontSrc = "font-src 'self' https://fonts.gstatic.com data:";
+        const string connectSrc = "connect-src 'self' https://*.google-analytics.com " +
+                                  "https://*.analytics.google.com https://*.googletagmanager.com";
+        return string.Join(";", defaultSrc, objectSrc, frameAncestors, upgradeInsecureRequests, blockAllMixedContent,
+            scriptSrc, imgSrc, formAction, styleSrc, fontSrc, connectSrc);
+    }
+
+    private string GenerateNonce()
+    {
+        var bytes = new byte[DefaultBytesInNonce];
+        _random.GetBytes(bytes);
+
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/src/EPR.Producer.PRN.Frontend.UI/Middleware/Auth/SecurityHeaderMiddleware.cs
+++ b/src/EPR.Producer.PRN.Frontend.UI/Middleware/Auth/SecurityHeaderMiddleware.cs
@@ -14,15 +14,10 @@ public class SecurityHeaderMiddleware
     {
         _next = next;
     }
-    public async Task SnibboAsync(HttpContext httpContext)
-    {
-        httpContext.Response.Headers.Append("X-Content-Type-Options", "nosniff");
-        await _next(httpContext);
-    }
 
     public async Task InvokeAsync(HttpContext httpContext, IConfiguration configuration)
     {
-        var scriptNonce = GenerateNonce();
+        var nonce = GenerateNonce();
         var whitelistedFormActionAddresses = configuration["AzureAdB2C:Instance"] ?? default!;
 
         const string permissionsPolicy =
@@ -32,7 +27,7 @@ public class SecurityHeaderMiddleware
             "oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=()," +
             "sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()";
 
-        httpContext.Response.Headers.Append("Content-Security-Policy", GetContentSecurityPolicyHeader(scriptNonce, whitelistedFormActionAddresses));
+        httpContext.Response.Headers.Append("Content-Security-Policy", GetContentSecurityPolicyHeader(nonce, whitelistedFormActionAddresses));
         httpContext.Response.Headers.Append("Cross-Origin-Embedder-Policy", "require-corp");
         httpContext.Response.Headers.Append("Cross-Origin-Opener-Policy", "same-origin");
         httpContext.Response.Headers.Append("Cross-Origin-Resource-Policy", "same-origin");
@@ -43,12 +38,12 @@ public class SecurityHeaderMiddleware
         httpContext.Response.Headers.Append("X-Permitted-Cross-Domain-Policies", "none");
         httpContext.Response.Headers.Append("X-Robots-Tag", "noindex, nofollow");
 
-        httpContext.Items[ContextKeys.ScriptNonceKey] = scriptNonce;
+        httpContext.Items[ContextKeys.ScriptNonceKey] = nonce;
 
         await _next(httpContext);
     }
 
-    private static string GetContentSecurityPolicyHeader(string scriptNonce, string whitelistedFormActionAddresses)
+    public static string GetContentSecurityPolicyHeader(string nonce, string whitelistedFormActionAddresses)
     {
         const string defaultSrc = "default-src 'self'";
         const string objectSrc = "object-src 'none'";
@@ -59,7 +54,7 @@ public class SecurityHeaderMiddleware
             "img-src 'self' www.googletagmanager.com https://ssl.gstatic.com https://www.gstatic.com " +
             "https://*.google-analytics.com https://*.googletagmanager.com";
         string scriptSrc =
-            $"script-src 'self' 'nonce-{scriptNonce}' https://tagmanager.google.com https://*.googletagmanager.com";
+            $"script-src 'self' 'nonce-{nonce}' https://tagmanager.google.com https://*.googletagmanager.com";
         string formAction = $"form-action 'self' {whitelistedFormActionAddresses}";
         const string styleSrc = "style-src 'self' https://tagmanager.google.com https://fonts.googleapis.com";
         const string fontSrc = "font-src 'self' https://fonts.gstatic.com data:";

--- a/src/EPR.Producer.PRN.Frontend.UI/Program.cs
+++ b/src/EPR.Producer.PRN.Frontend.UI/Program.cs
@@ -1,12 +1,29 @@
+using EPR.Producer.PRN.Frontend.UI.Middleware.Auth;
+using Microsoft.AspNetCore.HttpOverrides;
+
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddMvc();
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
+    options.ForwardedHostHeaderName = builder.Configuration.GetValue<string>("ForwardedHeaders:ForwardedHostHeaderName") ?? default!;
+    options.OriginalHostHeaderName = builder.Configuration.GetValue<string>("ForwardedHeaders:OriginalHostHeaderName") ?? default!;
+    options.AllowedHosts = (builder.Configuration.GetValue<string>("ForwardedHeaders:AllowedHosts") ?? default!).Split(";");
+});
+builder.Services.AddHsts(options =>
+{
+    options.IncludeSubDomains = true;
+    options.MaxAge = TimeSpan.FromDays(365);
+});
+builder.WebHost.ConfigureKestrel(options => options.AddServerHeader = false);
 var app = builder.Build();
 
 app.UseRouting();
+app.UseMiddleware<SecurityHeaderMiddleware>();
 app.MapControllerRoute(
-  name: "default",
-  pattern: "{controller=Home}/{action=Index}/{id?}",
-  defaults: new { controller = "Home", action = "Index" });
+    name: "default",
+    pattern: "{controller=Home}/{action=Index}/{id?}",
+    defaults: new { controller = "Home", action = "Index" });
 
 
 app.MapGet("/", () => "Hello World!");

--- a/src/EPR.Producer.PRN.Frontend.UI/appsettings.Development.json
+++ b/src/EPR.Producer.PRN.Frontend.UI/appsettings.Development.json
@@ -1,4 +1,9 @@
 {
+  "ForwardedHeaders": {
+    "ForwardedHostHeaderName": "X-Original-Host",
+    "OriginalHostHeaderName": "X-Initial-Host",
+    "AllowedHosts": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Add middleware to improve security and defend against cross site scripting attacks. Includes unit tests